### PR TITLE
Add permission to allow bot to function in private channels

### DIFF
--- a/slack_app_manifest.yaml
+++ b/slack_app_manifest.yaml
@@ -23,6 +23,7 @@ oauth_config:
       - channels:read
       - chat:write
       - commands
+      - groups:history
       - workflow.steps:execute
 settings:
   event_subscriptions:


### PR DESCRIPTION
Fails if executed in a private channel with:

`The server responded with: {'ok': False, 'error': 'missing_scope', 'needed': 'groups:history', 'provided': 'channels:history,channels:read,chat:write,commands,workflow.steps:execute'}
`

